### PR TITLE
Refactor API handler to support more request types

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"axios": "^0.18.0",
 		"lodash": "^4.17.11",
 		"polished": "^3.3.0",
+		"qs": "^6.7.0",
 		"react": "^16.8.6",
 		"react-dom": "^16.8.6",
 		"react-router-dom": "^5.0.0",

--- a/src/core/api.js
+++ b/src/core/api.js
@@ -1,50 +1,27 @@
 import axios from "axios";
 import { useEffect, useReducer } from "react";
 import { getSheetData } from "./utils";
+import { stringify } from "qs";
 
 const SHEET_ID = "1ZPRRR8T51Tk-Co8h_GBh3G_7P2F7ZrYxPQDSYycpCUg";
 const API_KEY = process.env.GOOGLE_API_KEY;
 
+// Create our API client and inject the API key into every request
 const client = axios.create({
   baseURL: `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/`,
   params: { key: API_KEY },
 });
 
-const getSheetByTitle = async title => {
-  const res = await client.get("values:batchGet", {
+// Utility for fetching a single sheet from a spreadsheet by its' title
+const getSheetByTitle = async title =>
+  await client.get("values:batchGet", {
     params: {
       majorDimension: "ROWS",
       ranges: title,
     },
   });
 
-  return res;
-};
-
-export default {
-  getSpreadsheet: () => client.get(""),
-  getSheetByTitle: title =>
-    client.get("values:batchGet", {
-      params: {
-        majorDimension: "ROWS",
-        ranges: title,
-      },
-    }),
-  getServiceByID: async (typeId, serviceId) => {
-    const sheet = await getSheetByTitle(typeId);
-    const rows = sheet.data.valueRanges[0].values;
-
-    const res = {};
-    const headers = rows[0];
-    //find the individual service row
-    const service = rows.filter(row => row[0] === serviceId);
-
-    //create response object with header key: value pairs
-    headers.map((heading, index) => (res[heading] = service[0][index]));
-    return res;
-  },
-};
-
+// Reducer that handles state for the useAPI hook
 const APIFetchReducer = (state, action) => {
   switch (action.type) {
     case "SUCCESS":
@@ -56,7 +33,13 @@ const APIFetchReducer = (state, action) => {
   }
 };
 
-export const useAPI = (url, opts) => {
+/**
+ * This hook used by the pages to handle API requests.
+ * It returns an object with the following keys:
+ * { loading, error, data }
+ */
+export const useAPI = (fetcher, opts) => {
+  // Create a reducer to store the status of the request
   const [state, dispatch] = useReducer(APIFetchReducer, {
     loading: true,
     error: false,
@@ -64,28 +47,69 @@ export const useAPI = (url, opts) => {
   });
 
   useEffect(() => {
+    /**
+     * didCancel is used if the component that made the request
+     * is unmounted while the request is still in-flight.
+     */
     let didCancel = false;
-
+    // Async fn to fetch the requested resource
     const fetchData = async () => {
       try {
-        const res = await client.get(url, opts);
-        const data = getSheetData(res.data);
+        const data = await fetcher(opts);
         if (!didCancel) {
+          // Dispatch a 'success' action if the request succeeded
           dispatch({ type: "SUCCESS", payload: data });
         }
       } catch (e) {
         if (!didCancel) {
+          // Dispatch a 'failure' action if the request failed
           dispatch({ type: "FAILURE" });
         }
       }
     };
-
+    // Run our asnyc fn!
     fetchData();
-
+    // If the component unmounts, set didCancel
     return () => {
       didCancel = true;
     };
   }, []);
-
+  // Return the current state of the reducer
   return state;
+};
+
+/**
+ * Handlers for the various types of data we want from the Sheets API
+ * They should return parsed sheet data, rather than the raw response
+ * from the API.
+ */
+export default {
+  // Returns *all* services as a single array—for use in search
+  getAllServices: async () => {
+    const index = await getSheetByTitle("Index");
+    const types = getSheetData(index.data).map(row => row[6]);
+    const allServicesRes = await client.get("values:batchGet", {
+      params: {
+        majorDimension: "ROWS",
+        ranges: types,
+      },
+      paramsSerializer: params => {
+        return stringify(params, { indices: false });
+      },
+    });
+    const allServices = allServicesRes.data.valueRanges.reduce((list, type) => {
+      return [...list, ...type.values];
+    }, []);
+    return allServices;
+  },
+  // Returns the spreadsheet's index sheet
+  getIndex: async () => {
+    const res = await getSheetByTitle("Index");
+    return getSheetData(res.data);
+  },
+  // Returns a list of services for a given type
+  getServicesByType: async type => {
+    const res = await getSheetByTitle(type);
+    return getSheetData(res.data);
+  },
 };

--- a/src/pages/categories/index.jsx
+++ b/src/pages/categories/index.jsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import Logo from "~/components/logo";
 import Loader from "~/components/loader";
 import { H1 } from "~/components/typography";
-import { useAPI } from "~/core/api";
+import api, { useAPI } from "~/core/api";
 import CategoryCard from "./category-card";
 
 const StyledLogo = styled(Logo)({
@@ -24,9 +24,7 @@ const IntroText = styled(H1)({
 });
 
 const Categories = () => {
-  const { loading, error, data } = useAPI("values:batchGet", {
-    params: { majorDimension: "ROWS", ranges: "Index" },
-  });
+  const { loading, error, data } = useAPI(api.getIndex);
 
   if (error) {
     return <p>Something went wrong!</p>;

--- a/src/pages/service-detail/index.jsx
+++ b/src/pages/service-detail/index.jsx
@@ -8,7 +8,7 @@ import PhysicalInfo from "~/components/physical-info";
 import Requirements from "~/components/requirements";
 import TitleBar from "~/components/title-bar";
 import { P1, P2 } from "~/components/typography";
-import { useAPI } from "~/core/api";
+import api, { useAPI } from "~/core/api";
 import { formatPhoneNumber, formatService } from "~/core/utils";
 
 const ServiceCard = styled(Box)({
@@ -32,9 +32,7 @@ const PhoneLink = styled.a({
 const ServiceDetail = ({ match }) => {
   const { categoryId, serviceId, typeId } = match.params;
 
-  const { loading, error, data } = useAPI("values:batchGet", {
-    params: { majorDimension: "ROWS", ranges: typeId },
-  });
+  const { loading, error, data } = useAPI(api.getServicesByType, typeId);
 
   if (loading) {
     return <Loader />;

--- a/src/pages/services/index.jsx
+++ b/src/pages/services/index.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import styled from "styled-components";
 import Loader from "~/components/loader";
 import TitleBar from "~/components/title-bar";
-import { useAPI } from "~/core/api";
+import api, { useAPI } from "~/core/api";
 import { formatService } from "~/core/utils";
 import ServiceCard from "./service-card";
 
@@ -15,9 +15,7 @@ const ServicesList = styled.ul({
 const Services = ({ match }) => {
   const { categoryId, typeId } = match.params;
 
-  const { loading, error, data } = useAPI("values:batchGet", {
-    params: { majorDimension: "ROWS", ranges: typeId },
-  });
+  const { loading, error, data } = useAPI(api.getServicesByType, typeId);
 
   if (loading) {
     return <Loader />;

--- a/src/pages/types/index.jsx
+++ b/src/pages/types/index.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from "react";
 import styled from "styled-components";
 import Loader from "~/components/loader";
 import TitleBar from "~/components/title-bar";
-import { useAPI } from "~/core/api";
+import api, { useAPI } from "~/core/api";
 import TypeCard from "./type-card";
 
 const TypesList = styled.ul({
@@ -13,9 +13,7 @@ const TypesList = styled.ul({
 
 const Types = ({ match }) => {
   const { categoryId } = match.params;
-  const { loading, error, data } = useAPI("values:batchGet", {
-    params: { majorDimension: "ROWS", ranges: "Index" },
-  });
+  const { loading, error, data } = useAPI(api.getIndex);
 
   if (loading) {
     return <Loader />;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5932,6 +5932,11 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
+qs@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
+  integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
+
 qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"


### PR DESCRIPTION
## Contents

* Refactor the `useAPI` hook to support passing in an asynchronous `fetcher` function, such as:
  * `getAllServices`
  * `getServicesByType`
  * ...etc.
* Update all pages to use the revised hook.

## TODO

- [x] Refactor `useAPI`
- [X] Write fetchers for `getAllServices`, `getIndex`, and `getServicesByType`
- [X] Update "Categories" page to use new hook
- [X] Update "Types" page to use new hook
- [X] Update "Services List" page to use new hook
- [X] Update "Service Detail" page to use new hook
